### PR TITLE
Add support for url-like image source

### DIFF
--- a/request.go
+++ b/request.go
@@ -40,8 +40,10 @@ type RequestCacheControl struct {
 }
 
 const (
-	RequestBodyMessagesMessagesContentTypeTextType  = "text"
-	RequestBodyMessagesMessagesContentTypeImageType = "image"
+	RequestBodyMessagesMessagesContentTypeTextType        = "text"
+	RequestBodyMessagesMessagesContentTypeImageType       = "image"
+	RequestBodyMessagesMessagesContentTypeImageSourceData = "data"
+	RequestBodyMessagesMessagesContentTypeImageSourceUrl  = "url"
 )
 
 type RequestBodyMessagesMessagesContentTypeText struct {
@@ -58,8 +60,9 @@ type RequestBodyMessagesMessagesContentTypeImage struct {
 
 type RequestBodyMessagesMessagesContentTypeImageSource struct {
 	Type      string `json:"type"`
-	MediaType string `json:"media_type"`
-	Data      string `json:"data"`
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+	Url       string `json:"url,omitempty"`
 }
 
 const (


### PR DESCRIPTION
Note that if url-fields and data-fields exist at the same time, claude will respond with error. A check can be added in parseBodyJSON() if you want to make sure that the user input should be cleaned.